### PR TITLE
Use the notoccite package

### DIFF
--- a/bib/example.bib
+++ b/bib/example.bib
@@ -30,3 +30,15 @@
  year          = "2004",
  url           = "https://cds.cern.ch/record/782076",
 }
+
+% Higgs papers
+@article{Higgs:1964ia,
+ author         = "Higgs, Peter W.",
+ title          = "{Broken symmetries, massless particles and gauge fields}",
+ journal        = "Phys. Lett.",
+ volume         = "12",
+ year           = "1964",
+ pages          = "132-133",
+ doi            = "10.1016/0031-9163(64)91136-9",
+ SLACcitation   = "%%CITATION = PHLTA,12,132;%%"
+}

--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -1,5 +1,6 @@
 % \usepackage{DL_thesis_v2016}
 \usepackage{adjustbox}       % TCM Extends the graphicx package to do trimming and other adjustments.
+\usepackage{notoccite} % Avoid references in captions causing numbering issues due to TOC
 \usepackage{algorithm}       % TCM Algorithm block See http://algorithms.berlios.de/
 \usepackage{algorithmic}     % TCM Algorithm & Peudocode See http://en.wikibooks.org/wiki/LaTeX/Algorithms_and_Pseudocode
 \usepackage{amsmath}         % Need for subequations
@@ -17,6 +18,7 @@
 \usepackage[flushleft]{threeparttable}  % TCM This package allows for notes under tables.  Flushleft option flushes the note left margin of table (center is default)
 \usepackage{geometry}		 % TCM Allows to customize paper size and margins.
 \usepackage{graphicx}        % TCM Extends graphics package for figures. Provides op­tional ar­gu­ments to the \in­clude­graph­ics com­mand
+\graphicspath{{images/figures/}}
 \usepackage{epstopdf}        % TCM Converts eps images to PDF to use in graphicx package.  Must be loaded after graphicx package
 \usepackage{longtable}       % TCM Allows for Automatic page breaks for long tables
 %\usepackage{jneurosci}       % TCM The jneurosci bibliography style makes use of some commands - for example, \citeauthoryear.  Must include if using named or acmsmall bib style

--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -1,3 +1,11 @@
 \chapter{Introduction}\label{chapter:introduction}
 
 This is the first chapter.~\cite{Aaboud:2016mmw,Bruning:782076}
+
+\begin{figure}[htpb]
+ \centering
+ \includegraphics{SMU_Logo_Red.eps}
+ \caption{This is a placeholder figure to act as an example.
+  Here we cite a new reference in the caption to demonstrate that given the package configuration our order of references will not be distributed by the table of contents.~\cite{Higgs:1964ia}}
+ \label{fig:test_figure}
+\end{figure}


### PR DESCRIPTION
As the package name alludes to, references in figure or table captions
that thus first appear in the table of contents will not be cited there,
but rather the first time that they appear in the main body of text.

c.f. https://ctan.org/pkg/notoccite?lang=en