### PR TITLE
Make \hypersetup{} metadata user owned

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After checking that it complies, you'll want to rename a few things and organize
 - `Makefile`: Change `user_thesis` to the name of whatever you renamed `user_thesis.tex` to
 - `bib/example.bib`: Rename to a descriptive name of the contents of the BibTeX file
    - **Suggestion:** Have multiple BibTeX files that correspond to different topics
+- `latex/metadata.tex`: Go through here and change all relevant data
 - `latex/FrontPages.tex`: Go through here and change all relevant data
 - `src/abstract.tex`: Replace with your abstract
 - `src/acknowledgements.tex`: Replace with your acknowledgements

--- a/latex/metadata.tex
+++ b/latex/metadata.tex
@@ -1,0 +1,29 @@
+\hypersetup{
+ % Added more precise definition and options for Hyperref package.
+ % Comment out or change hyperref preferences
+ % \hypersetup should be loaded last
+ bookmarksopen=true, % True: Open bookmark tree
+ bookmarksnumbered=true, % True: put section numbers in bookmarks
+ breaklinks=true, % True: split the url over multiple lines
+ %   draft=true, % True: do not do any hyper linking
+ filecolor=magenta, % Color of file links
+ citecolor=blue, % Color of links to bibliography
+ colorlinks=true, % False: boxed links; true: colored links
+ linkcolor=blue, % Color of internal links
+ linktocpage=true, % True: Makes the page number of TOC the link vs the text
+ %   pagebackref=true, % True: Links references back to referring page
+ pdfnewwindow=true, % True: URL links in new window
+ plainpages=false, % True: do page number anchors as plain Arabic
+ pdffitwindow=false, % Window fit to page when opened
+ pdfmenubar=true, % Show Acrobat menu
+ pdfstartview={FitH}, % Fits the width of the page to the window
+ pdftoolbar=true, % Show Acrobat toolbar
+ pdfauthor={Author}, % Author in PDF document properties
+ pdfcreator={Author}, % Creator of the document in PDF document properties
+ pdfkeywords={Keyword1} {Keyword2} {Keyword3} {Keyword4} {Author}, % List of keywords in PDF document properties
+ pdfproducer={Producer}, % Producer of the document in PDF document properties
+ pdfsubject={Subject}, % Subject of the document in PDF document properties
+ pdftitle={Title of Dissertation}, % Title in PDF document properties
+ unicode=false, % Non-Latin characters in Acrobat bookmarks
+ urlcolor=cyan % Color of external links
+}

--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -53,33 +53,4 @@
 \usepackage{wrapfig} % Wrap figures
 \usepackage{xspace} % Allows dynamic space in global text variables. This can allow you to just use \newCommandName rather than \newCommandName{}.
 \usepackage[bookmarks=true,backref=page, hyperfigures=true, pdfpagelabels=false]{hyperref}
-\hypersetup{
- % Added more precise definition and options for Hyperref package.
- % Comment out or change hyperref preferences
- % \hypersetup should be loaded last
- bookmarksopen=true, % True: Open bookmark tree
- bookmarksnumbered=true, % True: put section numbers in bookmarks
- breaklinks=true, % True: split the url over multiple lines
- %   draft=true, % True: do not do any hyper linking
- filecolor=magenta, % Color of file links
- citecolor=blue, % Color of links to bibliography
- colorlinks=true, % False: boxed links; true: colored links
- linkcolor=blue, % Color of internal links
- linktocpage=true, % True: Makes the page number of TOC the link vs the text
- %   pagebackref=true, % True: Links references back to referring page
- pdfnewwindow=true, % True: URL links in new window
- plainpages=false, % True: do page number anchors as plain Arabic
- pdffitwindow=false, % Window fit to page when opened
- pdfmenubar=true, % Show Acrobat menu
- pdfstartview={FitH}, % Fits the width of the page to the window
- pdftoolbar=true, % Show Acrobat toolbar
- pdfauthor={Author}, % Author in PDF document properties
- pdfcreator={Author}, % Creator of the document in PDF document properties
- pdfkeywords={Keyword1} {Keyword2} {Keyword3} {Keyword4} {Author}, % List of keywords in PDF document properties
- pdfproducer={Producer}, % Producer of the document in PDF document properties
- pdfsubject={Subject}, % Subject of the document in PDF document properties
- pdftitle={Title of Dissertation}, % Title in PDF document properties
- unicode=false, % Non-Latin characters in Acrobat bookmarks
- urlcolor=cyan % Color of external links
-}
 \usepackage{bookmark} % Eliminates Warning Bookmark level greater than one.  Must be loaded after Hyperref

--- a/update_template.sh
+++ b/update_template.sh
@@ -11,6 +11,7 @@ function install {
         mkdir latex
     fi
     rsync -r --update Dedman-Thesis-Latex-Template/latex/user_commands.tex ./latex/
+    rsync -r --update Dedman-Thesis-Latex-Template/latex/metadata.tex ./latex/
     rsync -r --update Dedman-Thesis-Latex-Template/latex/FrontPages.tex ./latex/
     rsync -r --update Dedman-Thesis-Latex-Template/latex/standalone_abstract.tex ./latex/
     rsync -r --update Dedman-Thesis-Latex-Template/src .

--- a/user_thesis.tex
+++ b/user_thesis.tex
@@ -7,6 +7,7 @@
 
 \input{latex/custom_commands.tex}
 % \input{latex/user_commands.tex} % Uncomment to use your own personal commands
+\input{latex/metadata.tex}
 
 % \thesisdraft % uncomment if want draft printing
 


### PR DESCRIPTION
Resolves #7 

As `\hypersetup{}` contains metadata specific to the individual thesis
this should not be in any base file, but rather be user controlled.

- [x] Migrate \hypersetup{} to a new file
- [x] Add instructions to the README to set \hypersetup{} metadata fields