### PR TITLE
Use export option for adjustbox package

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -21,7 +21,7 @@
 \usepackage[table]{xcolor} % Allows coloring of tables
 \usepackage{graphicx} % Extends graphics package for figures. Provides optional arguments to the \includegraphics command
 \graphicspath{{images/figures/}}
-\usepackage{adjustbox} % Extends the graphicx package to do trimming and other adjustments.
+\usepackage[export]{adjustbox} % Extends the graphicx package to do trimming and other adjustments.
 \usepackage{epstopdf} % Converts eps images to PDF to use in graphicx package.  Must be loaded after graphicx package
 \usepackage{longtable} % Allows for Automatic page breaks for long tables
 %\usepackage{jneurosci} % The jneurosci bibliography style makes use of some commands - for example, \citeauthoryear.  Must include if using named or acmsmall bib style


### PR DESCRIPTION
Resolves Issue #29 

`\usepackage[export]{adjustbox}` allows for easily setting maximum figure dimensions.

From the [release version 1.1 2018-04-08 package docs](https://ctan.org/pkg/adjustbox?lang=en) (Section: Package Options):

`export`: Exports most keys of `\adjustbox` to `\includegraphics` so that they can be used with this macro as well.