### PR TITLE
Use tr to make inputs lowercase

### DIFF
--- a/update_template.sh
+++ b/update_template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function install {
     # In case using an older version of Git
@@ -57,7 +57,9 @@ function main {
     else
         printf "Do you want to sync your base LaTeX files with the template? [Y/N]: "
         read -r response
-        if [[ "${response,,}" == "y" ]]; then
+        # MacOS can't use Bash 4.0+, so use old lowercase method
+        response="$(echo ${response} | tr [:upper:] [:lower:])"
+        if [[ "${response}" == "y" ]]; then
             update
             git diff --quiet Dedman-Thesis-Latex-Template
             if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
Resolves #32 

**Bug fix:**
As MacOS can't use Bash 4.0+ because the license causes problems for Apple the [modern way to lowercase strings in Bash](https://aty.sdsu.edu/bibliog/latex/debian/bash.html) won't work for MacOS users. Instead, use the old method of using [`tr`](https://explainshell.com/explain/1/tr) to translate all uppercase components of a string to lowercase.