### PR TITLE
Remove PreliminaryPages command

### DIFF
--- a/latex/front_pages.tex
+++ b/latex/front_pages.tex
@@ -18,7 +18,9 @@
  \input{src/abstract}
 \end{Abstract}
 
-\PreliminaryPages%
+\tableofcontents
+\listoffigures
+\listoftables
 
 % List of Symbols Page?
 % Uncomment to insert a list of symbols from symbols.tex (or elsewhere)

--- a/sty/DL_thesis.sty
+++ b/sty/DL_thesis.sty
@@ -817,12 +817,6 @@
  %\pagenumbering{roman} \setcounter{page}{3}  %%commented out by saeed
 }
 
-\def\PreliminaryPages{
- \tableofcontents
- \listoffigures
- \listoftables
-}
-
 \newenvironment{thesis}{
  \parskip 0.00in
  \if\@Dedication\Null \else


### PR DESCRIPTION
The `PreliminaryPages` command is totally unnecessary as it just copies a set of commands into the style file and doesn't add any functionality. These types of command obscure what is happening rather then making the template more readable and are bad.