### PR TITLE
Use subcaptions package

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -30,6 +30,7 @@
 \usepackage{moresize} % Adds \HUGE and \ssmall font sizes
 \usepackage{multirow} % Allows multirow cells in tables (similar to merge and center in Excel)
 %\usepackage{named} % Bibliography style that allows for more fine-tuned citing. Commands include \cite, \citeauthor, \citeyear and \shortcite (for after you've already used \citeauthor).
+\usepackage[list=true,listformat=simple]{subcaption} % Allow for subfigures with captions in table of contents
 \usepackage{outlines} % Needed for outlines
 \usepackage{rotate} % Performs rotations of floating environments (images w/ cations, etc)
 \usepackage{rotating} % Need for sidewaystable

--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -8,3 +8,24 @@ This is the first chapter of the \gls{thesis}.~\cite{Aaboud:2016mmw,Bruning:7820
  \caption{This is a placeholder figure to act as an example.
   Here we cite a new reference in the caption to demonstrate that given the package configuration our order of references will not be distributed by the table of contents.~\cite{Higgs:1964ia}}\label{fig:test_figure}
 \end{figure}
+
+As can be seen in Figure~\ref{fig:subfigure_example}, the subfigures are independent of each other such that Figure~\ref{fig:subfigure_1} and Figure~\ref{fig:subfigure_2} can be accessed separately.
+
+\begin{figure}[htbp]
+ \centering
+ \begin{subfigure}[t]{0.5\textwidth}
+  \centering
+  \includegraphics[width=0.3\textwidth]{introduction/example.pdf}
+  \caption{This is the first figure of two, in this example, and it its own independent subfigure.}
+  \label{fig:subfigure_1}
+ \end{subfigure}%
+ ~
+ \begin{subfigure}[t]{0.5\textwidth}
+  \centering
+  \includegraphics[width=0.3\textwidth]{introduction/example.pdf}
+  \caption{As the \texttt{t} alignment option was chosen for the subfigures, they are still properly aligned vertically even though this caption is longer.}
+  \label{fig:subfigure_2}
+ \end{subfigure}
+ \caption{An example of a figure that consists of two subfigures.}
+ \label{fig:subfigure_example}
+\end{figure}


### PR DESCRIPTION
Resolves #39 

`subcaption` "provides a means of using facilities analagous to those of the caption package, when writing captions for subfigures"
c.f. https://ctan.org/pkg/subcaption?lang=en

The use of the list option allows for the subfigure captions to show up in the table of content's list of figures.

An example is also added to the thesis template.