### PR TITLE
Add suggestion RE: capitalization of title

### DIFF
--- a/src/user_config.tex
+++ b/src/user_config.tex
@@ -3,6 +3,7 @@
 % \AuthorNameSuffix{Jr.}
 
 % Title can be up to three lines of no more than 48 characters per line
+% Write the title with the capitalization you want to be used in the abstract
 \ThesisTitle{Title first part}{continued title}{last part of title}
 \GraduateDepartment{Physics}
 


### PR DESCRIPTION
Resolves #56 

The title of abstract should not be all caps, and should only capitalize the first letter of important words, but this needs to be enforced at the user level. This warning can't do much, but hopefully helps.