### PR TITLE
Use hanging indent in bibliography

### DIFF
--- a/sty/DL_thesis.sty
+++ b/sty/DL_thesis.sty
@@ -305,15 +305,13 @@
   \usecounter{enumi}}
  \def\newblock{\hskip .11em plus .33em minus .07em}
  \sloppy\clubpenalty4000\widowpenalty4000
- \sfcode`\.=1000\relax}
+ \sfcode`\.=1000\relax
+ \setlength\itemindent{-20pt}}
 
-%% END of thebibliography
 %
 % \let\endthebibliography=\endlist
 %
-%------------------------------------------------------------------
 % END Bibliography
-%------------------------------------------------------------------
 %
 %------------------------------------------------------------------
 % BEGIN  Special caption style for table environment


### PR DESCRIPTION
Resolves #58 

To be consistent with SMU's thesis style all bibliography citations that are longer than one line should have a hanging indent.

This change was provided by @egodat from his 2018 thesis source code.