### PR TITLE
Single space committee members and title on signature page

### DIFF
--- a/sty/DL_thesis.sty
+++ b/sty/DL_thesis.sty
@@ -635,59 +635,66 @@
 %--------------------------------------------------------------------
 % END Title Page
 %--------------------------------------------------------------------
-%--------------------------------------------------------------------
-% BEGIN Approval Page
-%--------------------------------------------------------------------
+
+% Approval Page
 \def\Approvalpage{
- \thispagestyle{empty}  %added by saeed
+ \thispagestyle{empty}
  \setcounter{page}{1}
  \raggedbottom
- \vbox{\vspace{0.3in}}   %% 0.64 original julie %% changed by saeed to 0.3
+ \vbox{\vspace{0.3in}}
  \udtitle
  \vspace{1.0in}
  \begin{flushright}
   \parbox{3.0in}{\begin{flushleft}
     \hfill Approved by: \\ \  \\
-    %\vspace{0.1in} by saeed needed for 6 members
     \vspace{0.2in}
     \rule[-0.1in]{3.0in}{1pt} \\
-    \@AdvisorFullName \vspace{-0.1in} \\
-    \@AdvisorTitle \vspace{0.1in} \\
+    \vspace{-0.07cm}
+    \begin{singlespace}
+     \@AdvisorFullName\\
+     \@AdvisorTitle\\
+    \end{singlespace}
     \ifnum\numCmember>0 \rule[-0.1in]{3.0in}{1pt} \\
-     %                   \memberA \vspace{0.1in}  % by saeed if 6 members change to 0.1 inch
-     \memberA \vspace{-0.1in} \\ % TCM-changed vspace to -0.1in to accommedate titles per Dedman 2016 Standards, added \\, and moved \fi to line below
-     \membertitleA \\
+     \vspace{-0.07cm}
+     \begin{singlespace}
+      \memberA\\
+      \membertitleA\\
+     \end{singlespace}
     \fi
     \ifnum\numCmember>1 \rule[-0.1in]{3.0in}{1pt} \\
-     %                   \memberB \vspace{0.1in}  % by saeed if 6 members change to 0.1 inch
-     \memberB \vspace{-0.1in} \\ % TCM-changed vspace to -0.1in to accommedate titles per Dedman 2016 Standards, added \\, and moved \fi to line below
-     \membertitleB \\
+     \vspace{-0.07cm}
+     \begin{singlespace}
+      \memberB\\
+      \membertitleB\\
+     \end{singlespace}
     \fi
     \ifnum\numCmember>2 \rule[-0.1in]{3.0in}{1pt} \\
-     %                   \memberC \vspace{0.1in}  % by saeed if 6 members change to 0.1 inch
-     \memberC \vspace{-0.1in} \\ % TCM-changed vspace to -0.1in to accommedate titles per Dedman 2016 Standards, added \\, and moved \fi to line below
-     \membertitleC \\
+     \vspace{-0.07cm}
+     \begin{singlespace}
+      \memberC\\
+      \membertitleC\\
+     \end{singlespace}
     \fi
     \ifnum\numCmember>3 \rule[-0.1in]{3.0in}{1pt} \\
-     %                   \memberD \vspace{0.1in}  % by saeed if 6 members change to 0.1 inch
-     \memberD \vspace{-0.1in} \\ % TCM-changed vspace to -0.1in to accommedate titles per Dedman 2016 Standards, added \\, and moved \fi to line below
-     \membertitleD \\
+     \vspace{-0.07cm}
+     \begin{singlespace}
+      \memberD\\
+      \membertitleD\\
+     \end{singlespace}
     \fi
     \ifnum\numCmember>4 \rule[-0.1in]{3.0in}{1pt} \\
-     %                   \memberE
-     \memberE \vspace{-0.1in} \\ % TCM-changed vspace to -0.1in to accommedate titles per Dedman 2016 Standards, added \\, and moved \fi to line below
-     \membertitleE
+     \vspace{-0.07cm}
+     \begin{singlespace}
+      \memberE\\
+      \membertitleE\\
+     \end{singlespace}
     \fi
 
    \end{flushleft}}
  \end{flushright}
  \newpage
- %\pagenumbering{alph}   %%commented out by saeed
- %\setcounter{page}{0}   %%commented out by saeed
 }
-%--------------------------------------------------------------------
-% END Approval Page
-%--------------------------------------------------------------------
+
 %--------------------------------------------------------------------
 % BEGIN Abstract Page
 %--------------------------------------------------------------------


### PR DESCRIPTION
Resolves #55 

Using the singlespace environment provided by the setspace package ensures that the title of the committee member remains single spaced even if it is long enough to spill over to multiple lines