### PR TITLE
Add cleveref to default packages

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -55,6 +55,7 @@
 \usepackage{xspace} % Allows dynamic space in global text variables. This can allow you to just use \newCommandName rather than \newCommandName{}.
 \usepackage[bookmarks=true,backref=page, hyperfigures=true, pdfpagelabels=false]{hyperref}
 \usepackage{bookmark} % Eliminates Warning Bookmark level greater than one. Must be loaded after hyperref
+\usepackage{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
 \usepackage[utf8]{inputenc}
 \usepackage[toc,acronym]{glossaries} % place AFTER hyperref for hyperlinked glossary
 

--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -9,7 +9,7 @@ This is the first chapter of the \gls{thesis}.~\cite{Aaboud:2016mmw,Bruning:7820
   Here we cite a new reference in the caption to demonstrate that given the package configuration our order of references will not be distributed by the table of contents.~\cite{Higgs:1964ia}}\label{fig:test_figure}
 \end{figure}
 
-As can be seen in Figure~\ref{fig:subfigure_example}, the subfigures are independent of each other such that Figure~\ref{fig:subfigure_1} and Figure~\ref{fig:subfigure_2} can be accessed separately.
+As can be seen in \Cref{fig:subfigure_example}, the subfigures are independent of each other such that \Cref{fig:subfigure_1} and \Cref{fig:subfigure_2} can be accessed separately.
 
 \begin{figure}[htbp]
  \centering


### PR DESCRIPTION
# Description

Resolves #68 

Use the [`cleveref`](https://ctan.org/pkg/cleveref) package for easier and more uniform referencing of figures, tables, and sections.