### PR TITLE
Format cleveref equation references to not have parentheses

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -56,6 +56,7 @@
 \usepackage[bookmarks=true,backref=page, hyperfigures=true, pdfpagelabels=false]{hyperref}
 \usepackage{bookmark} % Eliminates Warning Bookmark level greater than one. Must be loaded after hyperref
 \usepackage{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
+\creflabelformat{equation}{#2\textup{#1}#3}% Equation references don't have parentheses
 \usepackage[utf8]{inputenc}
 \usepackage[toc,acronym]{glossaries} % place AFTER hyperref for hyperlinked glossary
 

--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -30,6 +30,13 @@ As can be seen in \Cref{fig:subfigure_example}, the subfigures are independent o
  \label{fig:subfigure_example}
 \end{figure}
 
+As an example of an equation formatted in ``\href{https://www.overleaf.com/learn/latex/Display_style_in_math_mode}{display style}'' the equation for the fiducial cross section from~\cite{Aaboud:2016mmw} is reproduced as \Cref{eq:fiducial_cross_section}:
+
+\begin{equation}
+ \sigma_{\mathrm{inel}}^{\mathrm{fid}} \left(\zeta > 10^{-6}\right) = \frac{N - N_{\mathrm{BG}}}{\epsilon_{\mathrm{trig}} \times \mathcal{L}} \times \frac{1 - f_{\zeta < 10^{-6}}}{\epsilon_{\mathrm{sel}}}
+ \label{eq:fiducial_cross_section}
+\end{equation}
+
 \section{Dealing with Widows and Orphans}
 
 To reduce the difficulty of dealing with widowed text (the last line of a paragraph at the start of a page) and orphaned text (the first line of paragraph at the end of a page) the \href{https://ctan.org/pkg/nowidow?lang=en}{\texttt{nowidow}} package is used.


### PR DESCRIPTION
# Description

Amends PR #69 

Set the formatting of  `cleveref`'s equation references so that the generated references in the text do not have parentheses around the equation number. Keep the parentheses around the equation number on the right hand side of the typeset equations.

Additionally add an example equation to demonstrate the formatting choice.