### PR TITLE
Add glossary guards to TOC and lists of figures/tables

### DIFF
--- a/latex/front_pages.tex
+++ b/latex/front_pages.tex
@@ -18,9 +18,11 @@
  \input{src/abstract}
 \end{Abstract}
 
-\tableofcontents
-\listoffigures
-\listoftables
+\glsunsetall%
+\tableofcontents%
+\listoffigures%
+\listoftables%
+\glsresetall%
 
 % List of Symbols Page?
 % Uncomment to insert a list of symbols from symbols.tex (or elsewhere)

--- a/src/glossary.tex
+++ b/src/glossary.tex
@@ -1,5 +1,9 @@
 \newglossaryentry{LHC}{
- name=LHC,
+ text=LHC,
+ long=Large Hadron Collider,
+ name={\glsentrylong{LHC} (\glsentrytext{LHC})},
+ first={\glsentryname{LHC}},
+ sort={large hadron collider},
  description={Large Hadron Collider}
 }
 

--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -5,7 +5,8 @@ This is the first chapter of the \gls{thesis}.~\cite{Aaboud:2016mmw,Bruning:7820
 \begin{figure}[htpb]
  \centering
  \includegraphics{introduction/example.pdf}
- \caption[Example placeholder figure with a citation~\cite{Higgs:1964ia} and shorter List of Figures caption.]{%
+ \caption[Example placeholder figure with a citation~\cite{Higgs:1964ia} and shorter List of Figures caption.
+  The List of Figures is protected from first use of glossary entries or acronyms like \acrlong{LHC}.]{%
   This is a placeholder figure to act as an example.
   Here we cite a new reference in the caption to demonstrate that given the package configuration our order of references will not be distributed by the table of contents~\cite{Higgs:1964ia}.}\label{fig:test_figure}
 \end{figure}

--- a/src/preface.tex
+++ b/src/preface.tex
@@ -10,7 +10,7 @@ Discussion of units
 
 \section{Coordinates}\label{section:coordinates}
 
-\Gls{LHC} coordinate systems
+\gls{LHC} coordinate systems
 
 \section{Statistics}\label{section:statistics}
 


### PR DESCRIPTION
# Description

Resolves #78 

Unsetting and resetting the glossary keeps glossary entries from being evaluated in the List of Figures/Tables.

c.f. https://en.wikibooks.org/wiki/LaTeX/Glossary#Referring_acronyms