### PR TITLE
Use better spacing for side-by-side subfigures

### DIFF
--- a/src/introduction.tex
+++ b/src/introduction.tex
@@ -15,15 +15,15 @@ As can be seen in \Cref{fig:subfigure_example}, the subfigures are independent o
 
 \begin{figure}[htbp]
  \centering
- \begin{subfigure}[t]{0.5\textwidth}
+ \begin{subfigure}[t]{0.48\textwidth}
   \centering
   \includegraphics[width=0.3\textwidth]{introduction/example.pdf}
   \caption[Short List of Figures captions work with subfigures too.]{%
    This is the first figure of two, in this example, and its own independent subfigure.}
   \label{fig:subfigure_1}
  \end{subfigure}%
- ~
- \begin{subfigure}[t]{0.5\textwidth}
+ \quad
+ \begin{subfigure}[t]{0.48\textwidth}
   \centering
   \includegraphics[width=0.3\textwidth]{introduction/example.pdf}
   \caption[Which makes the List of Figures readable and actually helpful.]{%


### PR DESCRIPTION
# Description

Resolve #80 

Using `0.5\textwidth` can be problematic as the captions are then too close to each other. A more reasonable choice is `0.48\textwidth` with `\quad` spacing.