### PR TITLE
Add printer calibration

### DIFF
--- a/latex/custom_commands.tex
+++ b/latex/custom_commands.tex
@@ -312,3 +312,35 @@
 %======================================================================
 % END SMU Custom Commands
 %======================================================================
+\newcommand{\printercalibration}{%
+ \begin{tikzpicture}[remember picture,overlay]
+  % 1 inch printer calibration
+  \draw[line width=4pt,red,arrows=->] (current page.north west) ++(1in,0)
+  -- node[midway,anchor=east,red] {top = 1 in} ++(0,-1in)
+  -- node[midway,anchor=north,red] {side = 1 in}
+  ++(-1in,0);
+  \draw[line width=4pt,red,arrows=->] (current page.south east) ++(-1in,0)
+  -- ++(0,1in)
+  -- ++(1in,0);
+  % 2 inch printer calibration
+  \draw[line width=4pt,blue,arrows=->] (current page.north)
+  -- node[pos=0.7,anchor=west,blue] {2 in}
+  ++(0,-2in);
+  \draw[line width=4pt,blue,arrows=->] (current page.east)
+  -- node[pos=0.7,anchor=south,blue] {2 in}
+  ++(-2in,0);
+  \draw[line width=4pt,blue,arrows=->] (current page.south)
+  -- node[pos=0.7,anchor=west,blue] {2 in}
+  ++(0,2in);
+  \draw[line width=4pt,blue,arrows=->] (current page.west)
+  -- node[pos=0.7,anchor=south,blue] {2 in}
+  ++(2in,0);
+  % 2 inch box
+  \filldraw (current page.center) circle (1pt);
+  \node [draw, thick, blue, shape=rectangle, minimum width=2in, minimum height=2in, anchor=center] at (current page.center) {};
+  \draw (current page.center) ++(0,1in) node [blue, above] {2 inches};
+  % 1 inch box
+  \node [draw, thick, red, shape=rectangle, minimum width=1in, minimum height=1in, anchor=center] at (current page.center) {};
+  \draw (current page.center) ++(0,0.5in) node [red, above] {1 inch};
+ \end{tikzpicture}
+}

--- a/src/printer_calibration.tex
+++ b/src/printer_calibration.tex
@@ -1,0 +1,18 @@
+\chapter{Printer Calibration}\label{chapter:printer_calibration}
+
+As you may know, printers do not print your PDF file exactly.
+They will scale it to match their own preset configurations and potentially add padding spaces around the edges.
+There is no way to control for this as every printer is unique and there are no base standards.
+The only thing a user can do is have their generated PDF file have the correct distances and then ask that the person printing their document calibrate the printer accordingly.
+
+\printercalibration{}
+
+\vspace{2.5in}
+This chapter will provide printer calibrations.
+All the \textcolor{red}{red lines} drawn are $1$~inch in length.
+All the \textcolor{blue}{blue lines} drawn are $2$~inches in length.
+These are drawn from the edge of the document in TikZ, which has good distance metrics built into it, so these distances are accurate.
+Print this page and measure the margins and the length of the arrows.
+If your measurements do not match those printed \textbf{you need to calibrate your printer}.
+It is probable that your printer has an option that is along the lines of ``actual size'', so that might be a good starting point.
+It can also help to turn on \verb|\geometry{showframe=true}| in your preamble.

--- a/user_thesis.tex
+++ b/user_thesis.tex
@@ -26,6 +26,8 @@
 
  \input{src/introduction.tex}
 
+ \input{src/printer_calibration.tex}
+
  \StartAppendix%
 
  \input{src/appendix_A.tex}


### PR DESCRIPTION
# Description

Related to #53 and #54. This adds a printer calibration chapter that draws lines that are 1 inch and 2 inches in length on the page using TikZ for accurate distance scales. This page can be used to calibrate a printer or to determine if margins in the document are properly set.