### PR TITLE
Control double and single spacing with setspace package

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -37,7 +37,7 @@
 \usepackage{scrextend} % package that allows for KOMA-Script classes available for other classes: e.g., labeling lists etc.  See package documentation for further information.
 \usepackage{pdflscape} % Allows Landscape Page
 %%\usepackage{qtree} % Need for trees
-\usepackage{setspace} % Allows for more intuitive commands for single and double spacing
+\usepackage[doublespacing]{setspace} % Allows for more intuitive commands for single and double spacing
 \usepackage{siunitx} % package required to ensure units are typeset properly with numbers e.g. \SI{10}{\kg\m\per\square\s}
 \sisetup{output-exponent-marker=\ensuremath{\mathrm{E}}} % Option allows for Scientific notation of Numbers. Format is \num{#.####E##}
 \usepackage[all]{nowidow} % https://ctan.org/pkg/nowidow
@@ -58,6 +58,6 @@
 \usepackage{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
 \creflabelformat{equation}{#2\textup{#1}#3}% Equation references don't have parentheses
 \usepackage[utf8]{inputenc}
-\usepackage[toc,acronym]{glossaries} % place AFTER hyperref for hyperlinked glossary
+\usepackage[nogroupskip,toc,acronym]{glossaries} % place AFTER hyperref for hyperlinked glossary
 
 \usepackage{lineno} % Provide line numbers for drafts

--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -20,7 +20,7 @@
 
 \newgeometry{letterpaper, margin=1in} % Dedman/Lyle Standard 2016
 
-\linespread{1.6}
+\doublespacing%
 \setcounter{secnumdepth}{4} % Sets number subsections
 \setcounter{tocdepth}{4} % Set the number of subsections in TOC
 

--- a/sty/DL_thesis.sty
+++ b/sty/DL_thesis.sty
@@ -62,8 +62,7 @@
   \sectionmark{#1}
   \noindent %T
   %T \centerline{$\underline{\hbox{\thesection.} _{\ } \ \hbox{#1}}$}
-  \Null {\bf \thesection. \ #1}%T Removed preceeding space before bf which makes headers misaligned TCM
-  \vskip -0.23in %% Julie
+  \Null \textbf{\thesection. \ #1}%T Removed preceeding space before bf which makes headers misaligned TCM
   \indent
  }
 
@@ -78,7 +77,6 @@
  \centerline{$\underline{\hbox{\thesection.} _{\ } \ \hbox{#1}}$}
  \centerline{$\underline{\hbox{\thesection.} _{\ } \ \hbox{#1}}$}
  \centerline{$\underline{_{\ } \hbox{#2}}$}
- \vskip -0.09in %% Julie
  \indent
 }
 
@@ -91,9 +89,7 @@
  %T \centerline{\thesubsection. \ #1}
  \noindent %T
  \Null \thesubsection. \ #1
- \vskip -0.27in  %% Julie: space betw. name to the fisrt line
  \indent
-
 }
 
 \def\subsectiondl#1#2{\vskip 0.25in \ifnum \c@secnumdepth >\m@ne
@@ -102,8 +98,6 @@
    \numberline{\thesubsection.}#1 #2}\else
   \addcontentsline{toc}{subsection}{#1 #2}\fi
  \subsectionmark{#1}
-
-
 }
 
 \def\subsubsection#1{\vskip 0.25in \ifnum \c@secnumdepth >\m@ne
@@ -113,13 +107,9 @@
   \addcontentsline{toc}{subsubsection}{#1}\fi
  \subsubsectionmark{#1}
  \noindent
- %\centerline{\thesubsubsection. \ #1}  %% title is on the middle originally
- %T\Null \thesubsubsection. \ #1  %% Julie move it to the left ( standard requirement)
  \Null {\em \thesubsubsection. \ #1 } %% Julie move it to the left ( standard requirement) % Removed preceeding space before em which makes headers misaligned TCM
  %T \Null added to show first numeral
- \vskip -0.27in
  \indent
-
 }
 
 \def\subsubsectiondl#1#2{\vskip 0.25in \ifnum \c@secnumdepth >\m@ne
@@ -131,7 +121,6 @@
  \noindent
  \centerline{\em \thesubsubsection. \ #1} \vskip -0.08in
  \centerline{\em #2}
- \vskip -0.27in
  \indent
 }
 

--- a/user_thesis.tex
+++ b/user_thesis.tex
@@ -35,8 +35,10 @@
  % Glossary
  % Check with specific department on the style to use
  \clearpage
+ \singlespacing%
  \setglossarystyle{list}
  \printglossary[title=GLOSSARY,toctitle=GLOSSARY]
+ \doublespacing%
 
  % Bibliography goes below
  % Check with specific department on the appropriate


### PR DESCRIPTION
# Description

Remove bad manual attempts at setting the spacing of section titles and general single vs. double spacing and use the [`setspace` pacakge](https://ctan.org/pkg/setspace?lang=en) to control spacing instead. Also 

```
* Remove bad manual attempts at setting the spacing of section titles
* Use setspace package to control single vs. double spacing
c.f. https://ctan.org/pkg/setspace?lang=en
* Use setspace commands to single space lines in glossary
```