### PR TITLE
Use amssymb over user custom commands

### DIFF
--- a/latex/custom_commands.tex
+++ b/latex/custom_commands.tex
@@ -196,8 +196,6 @@
 \newcommand{\myup}{\protect{$ \uparrow$}}
 \newcommand{\scc}[1]{\protect{\ \ \ $ SCC = {#1} $}}
 
-\newcommand{\twoheadrightarrow}{{\rightarrow \hspace{-0.3cm} \rightarrow \hspace{0.2cm}}}
-
 \newcommand{\chap}[1]{\chapter{\protect{\bf {#1}}}}
 \newcommand{\mytab}{\hspace*{13em}}
 \newcommand{\bleft}{\left \{\ }

--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -4,7 +4,7 @@
 \usepackage{algorithmic} % Algorithm & Peudocode See http://en.wikibooks.org/wiki/LaTeX/Algorithms_and_Pseudocode
 \usepackage{amsmath} % Need for subequations
 \usepackage{mathrsfs} %https://ctan.org/pkg/mathrsfs
-%\usepackage{amssymb} % amssymb-telda and math symbols
+\usepackage{amssymb} % amssymb-telda and math symbols
 \usepackage{booktabs} % Allows fancy Tables
 \usepackage{boxedminipage} % Boxes around figures
 \usepackage{breqn} % Automatically breaks long equation lines - usually


### PR DESCRIPTION
# Description

There was a user defined custom command in `latex/custom_commands.tex` 

https://github.com/matthewfeickert/Dedman-Thesis-Latex-Template/blob/3a515fad8824ba3dc2d56c4e69a7e4c15f761c57/latex/custom_commands.tex#L199

that when removed allowed for use of `amssymb`.