### PR TITLE
Use capitalize option as default for cleveref package

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -55,7 +55,7 @@
 \usepackage{xspace} % Allows dynamic space in global text variables. This can allow you to just use \newCommandName rather than \newCommandName{}.
 \usepackage[bookmarks=true,backref=page, hyperfigures=true, pdfpagelabels=false]{hyperref}
 \usepackage{bookmark} % Eliminates Warning Bookmark level greater than one. Must be loaded after hyperref
-\usepackage{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
+\usepackage[capitalize]{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
 \creflabelformat{equation}{#2\textup{#1}#3}% Equation references don't have parentheses
 \usepackage[utf8]{inputenc}
 \usepackage[nogroupskip,toc,acronym]{glossaries} % place AFTER hyperref for hyperlinked glossary


### PR DESCRIPTION
# Description

Use the capitalize option for the [`cleveref`](https://www.ctan.org/pkg/cleveref) package to enforce the style option of always having the reference be capitalized, regardless if `\Cref` or `\cref` is used. Thanks to @danjardin for this idea.