### PR TITLE
Add Git pre-commit hooks to template

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Redirect output to stderr.
+exec 1>&2
+
+if [ "$(git grep -E "(\b[a-zA-Z]+) \1\b" -- '*.tex')" ]; then
+	cat <<\EOF
+
+COMMIT FAILED: There are repeated words in your LaTeX files, which is probably a typo:
+
+EOF
+	git grep -E "(\b[a-zA-Z]+) \1\b" -- '*.tex'
+
+	cat <<\EOF
+
+If this is intentional you can force the commit by using the --no-verify option.
+
+EOF
+	exit 1
+fi

--- a/update_template.sh
+++ b/update_template.sh
@@ -66,12 +66,8 @@ function install {
     cp -r Dedman-Thesis-Latex-Template/figures .
     cp -r Dedman-Thesis-Latex-Template/bib .
     install_check "Makefile"
-    if [ ! -d ".githooks" ]; then
-        mkdir .githooks
-    fi
-    install_check ".githooks/pre-commit"
-    if [[ $? -eq 0 ]]; then
-        # Keep .githooks/pre-commit under template control
+    if [[ ! -f ".git/hooks/pre-commit" ]]; then
+        # Keep .git/hooks/pre-commit under template control if they don't exist
         # https://stackoverflow.com/a/4594681/8931942
         ln -s -f ../../Dedman-Thesis-Latex-Template/.githooks/pre-commit .git/hooks/pre-commit
     fi

--- a/update_template.sh
+++ b/update_template.sh
@@ -66,6 +66,15 @@ function install {
     cp -r Dedman-Thesis-Latex-Template/figures .
     cp -r Dedman-Thesis-Latex-Template/bib .
     install_check "Makefile"
+    if [ ! -d ".githooks" ]; then
+        mkdir .githooks
+    fi
+    install_check ".githooks/pre-commit"
+    if [[ $? -eq 0 ]]; then
+        # Keep .githooks/pre-commit under template control
+        # https://stackoverflow.com/a/4594681/8931942
+        ln -s -f ../../Dedman-Thesis-Latex-Template/.githooks/pre-commit .git/hooks/pre-commit
+    fi
 
     # Use the template base files
     # -i.bak is used for compatability across GNU and BSD/macOS sed


### PR DESCRIPTION
# Description

Use Git pre-commit hooks to check for repeated words in the source files and warn user if any are found. Also install this with the rest of the template.

At the moment the pre-commit hook is being kept under template control, but an advanced user only needs to change the symlink in their `.git/hooks/pre-commit`.